### PR TITLE
Connect Profile Page with Information from Auth Store

### DIFF
--- a/services/delivery-ui/src/features/profile/pages/ProfilePage.spec.tsx
+++ b/services/delivery-ui/src/features/profile/pages/ProfilePage.spec.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ProfilePage } from './ProfilePage';
-import { User } from '@/core';
+import { LocalStorageKey, User } from '@/core';
 
 const userStub: User = {
   id: '1',
@@ -43,6 +43,8 @@ describe('ProfilePage', () => {
   });
 
   it('should unauthenticate user on logout button click', async () => {
+    const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem');
+
     render(<ProfilePage />);
 
     const logoutButton = screen.getByTestId('logout-button');
@@ -50,6 +52,8 @@ describe('ProfilePage', () => {
     fireEvent.click(logoutButton);
 
     await waitFor(() => {
+      expect(removeItemSpy).toHaveBeenCalledTimes(1);
+      expect(removeItemSpy).toHaveBeenCalledWith(LocalStorageKey.AccessToken);
       expect(unauthenticateSpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/services/delivery-ui/src/features/profile/pages/ProfilePage.spec.tsx
+++ b/services/delivery-ui/src/features/profile/pages/ProfilePage.spec.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProfilePage } from './ProfilePage';
+import { User } from '@/core';
+
+const userStub: User = {
+  id: '1',
+  email: 'john.doe@dp-demo.io',
+  firstname: 'John',
+  lastname: 'Doe',
+  companyId: '1',
+  companyName: 'Beeliver',
+};
+
+const unauthenticateSpy = vi.fn();
+
+vi.mock('@/core', async (importOriginal) => {
+  const original: object = await importOriginal();
+
+  return {
+    ...original,
+    useAuthStore: () => ({
+      user: userStub,
+      unauthenticate: unauthenticateSpy,
+    }),
+  };
+});
+
+describe('ProfilePage', () => {
+  afterEach(() => {
+    cleanup();
+
+    vi.clearAllMocks();
+  });
+
+  it('should render user information from the auth store on form', async () => {
+    render(<ProfilePage />);
+
+    expect(await screen.findByTestId('email-input')).toHaveValue(userStub.email);
+    expect(await screen.findByTestId('firstname-input')).toHaveValue(userStub.firstname);
+    expect(await screen.findByTestId('lastname-input')).toHaveValue(userStub.lastname);
+    expect(await screen.findByTestId('delivery-company-input')).toHaveValue(userStub.companyName);
+  });
+});

--- a/services/delivery-ui/src/features/profile/pages/ProfilePage.spec.tsx
+++ b/services/delivery-ui/src/features/profile/pages/ProfilePage.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ProfilePage } from './ProfilePage';
 import { User } from '@/core';
@@ -40,5 +40,17 @@ describe('ProfilePage', () => {
     expect(await screen.findByTestId('firstname-input')).toHaveValue(userStub.firstname);
     expect(await screen.findByTestId('lastname-input')).toHaveValue(userStub.lastname);
     expect(await screen.findByTestId('delivery-company-input')).toHaveValue(userStub.companyName);
+  });
+
+  it('should unauthenticate user on logout button click', async () => {
+    render(<ProfilePage />);
+
+    const logoutButton = screen.getByTestId('logout-button');
+
+    fireEvent.click(logoutButton);
+
+    await waitFor(() => {
+      expect(unauthenticateSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/services/delivery-ui/src/features/profile/pages/ProfilePage.tsx
+++ b/services/delivery-ui/src/features/profile/pages/ProfilePage.tsx
@@ -9,7 +9,7 @@ export const ProfilePage = () => {
 
   return (
     <DashboardLayout title="Profile" description="Information about your profile.">
-      <Stack spacing={20} as="form">
+      <Stack spacing={10} as="form">
         <Stack spacing={5} fontSize="lg">
           <FormControl>
             <FormLabel htmlFor="email">Email</FormLabel>

--- a/services/delivery-ui/src/features/profile/pages/ProfilePage.tsx
+++ b/services/delivery-ui/src/features/profile/pages/ProfilePage.tsx
@@ -1,9 +1,12 @@
 import { Button, FormControl, FormLabel, Input, Stack } from '@chakra-ui/react';
 import { useLocation } from 'wouter';
-import { DashboardLayout, Routes } from '@/core';
+import { DashboardLayout, Routes, useAuthStore } from '@/core';
 
 export const ProfilePage = () => {
   const [_, setLocation] = useLocation();
+  const { user } = useAuthStore((state) => ({
+    user: state.user,
+  }));
 
   return (
     <DashboardLayout title="Profile" description="Information about your profile.">
@@ -11,23 +14,42 @@ export const ProfilePage = () => {
         <Stack spacing={5} fontSize="lg">
           <FormControl>
             <FormLabel htmlFor="email">Email</FormLabel>
-            <Input id="email" variant="filled" disabled={true} value="john.doe@gmail.com" />
+            <Input
+              id="email"
+              data-testid="email-input"
+              variant="filled"
+              disabled={true}
+              value={user?.email}
+            />
           </FormControl>
           <FormControl>
             <FormLabel htmlFor="firstname">Firstname</FormLabel>
-            <Input id="firstname" variant="filled" disabled={true} value="John" />
+            <Input
+              id="firstname"
+              data-testid="firstname-input"
+              variant="filled"
+              disabled={true}
+              value={user?.firstname}
+            />
           </FormControl>
           <FormControl>
             <FormLabel htmlFor="lastname">Lastname</FormLabel>
-            <Input id="firstname" variant="filled" disabled={true} value="Doe" />
-          </FormControl>
-          <FormControl>
-            <FormLabel htmlFor="deliverycompany">Delivery company</FormLabel>
             <Input
-              id="deliverycompany"
+              id="firstname"
+              data-testid="lastname-input"
               variant="filled"
               disabled={true}
-              value="Beeliver Delivers"
+              value={user?.lastname}
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel htmlFor="delivery-company">Delivery company</FormLabel>
+            <Input
+              id="delivery-company"
+              data-testid="delivery-company-input"
+              variant="filled"
+              disabled={true}
+              value={user?.companyName}
             />
           </FormControl>
         </Stack>

--- a/services/delivery-ui/src/features/profile/pages/ProfilePage.tsx
+++ b/services/delivery-ui/src/features/profile/pages/ProfilePage.tsx
@@ -1,11 +1,10 @@
 import { Button, FormControl, FormLabel, Input, Stack } from '@chakra-ui/react';
-import { useLocation } from 'wouter';
-import { DashboardLayout, Routes, useAuthStore } from '@/core';
+import { DashboardLayout, useAuthStore } from '@/core';
 
 export const ProfilePage = () => {
-  const [_, setLocation] = useLocation();
-  const { user } = useAuthStore((state) => ({
+  const { user, unauthenticate } = useAuthStore((state) => ({
     user: state.user,
+    unauthenticate: state.unauthenticate,
   }));
 
   return (
@@ -56,8 +55,9 @@ export const ProfilePage = () => {
 
         <Button
           onClick={() => {
-            setLocation(Routes.Login);
+            unauthenticate();
           }}
+          data-testid="logout-button"
         >
           Logout
         </Button>

--- a/services/delivery-ui/src/features/profile/pages/ProfilePage.tsx
+++ b/services/delivery-ui/src/features/profile/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import { Button, FormControl, FormLabel, Input, Stack } from '@chakra-ui/react';
-import { DashboardLayout, useAuthStore } from '@/core';
+import { DashboardLayout, LocalStorageKey, useAuthStore } from '@/core';
 
 export const ProfilePage = () => {
   const { user, unauthenticate } = useAuthStore((state) => ({
@@ -55,6 +55,7 @@ export const ProfilePage = () => {
 
         <Button
           onClick={() => {
+            localStorage.removeItem(LocalStorageKey.AccessToken);
             unauthenticate();
           }}
           data-testid="logout-button"


### PR DESCRIPTION
## Description

- Displays user information from `authStore` on `ProfilePage`
- Removes jwt from local storage and unauthanticates user on `Logout` click

## Type of PR?
- [x] Feature
- [x] Test

## Screenshots

![image](https://github.com/user-attachments/assets/5a091d16-9bb4-465e-9032-79d434d73e11)
